### PR TITLE
Updated files to pass current jshint configuration on @thrabchak fork.

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -1,44 +1,44 @@
-<!doctype html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
-  <head>
-  	<title>Game Title</title>
-	<meta charset="UTF-8" />
-    <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-    <meta name="mobile-web-app-capable" context="yes">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
-    <meta name="keywords" content=""/>
-    <meta name="description" content=""/>
+	<head>
+		<title>Game Title</title>
+		<meta charset="UTF-8" />
+		<meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+		<meta name="mobile-web-app-capable" content="yes">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+		<meta name="keywords" content=""/>
+		<meta name="description" content=""/>
 
-    <link rel="icon" size="196x196" href="assets/graphics/icon.png">
-    <link href="style.css" rel="stylesheet" type="text/css" media="screen"/>
+		<link rel="icon" sizes="196x196" href="assets/graphics/icon.png">
+		<link href="style.css" rel="stylesheet" type="text/css" media="screen"/>
+	</head>
 
-	<section>
-		<script type="text/javascript" src="src/phaser/phaser.js"></script>
-		<script type="text/javascript" src="src/three/three.js"></script>
-		
-		<script type="text/javascript" src="src/game/JsUtils.js"></script>
-		<script type="text/javascript" src="src/game/Layer3d.js"></script>
+	<body>
+		<section>
+			<script type="text/javascript" src="src/phaser/phaser.js"></script>
+			<script type="text/javascript" src="src/three/three.js"></script>
 
-		<script type="text/javascript" src="src/game/GameTitle.js"></script>
-		<script type="text/javascript" src="src/game/Boot.js"></script>
-		<script type="text/javascript" src="src/game/Preloader.js"></script>
-		<script type="text/javascript" src="src/game/MainMenu.js"></script>
-		<script type="text/javascript" src="src/game/Game.js"></script>
-		<script type="text/javascript" src="src/game/GameLayer3d.js"></script>
-		<script type="text/javascript" src="src/game/About.js"></script>
-	</section>
-</head>
+			<script type="text/javascript" src="src/game/JsUtils.js"></script>
+			<script type="text/javascript" src="src/game/Layer3d.js"></script>
 
-<body>
-  <!--TODO: Need to insert the cordova.js script node at build time.-->
-  <script type="text/javascript" src="cordova.js"></script>
-  
-	<script type="text/javascript">
-		window.onload = function()
-		{
-		  GameTitle.run();
-		}
-	</script>
-</body>
+			<script type="text/javascript" src="src/game/GameTitle.js"></script>
+			<script type="text/javascript" src="src/game/Boot.js"></script>
+			<script type="text/javascript" src="src/game/Preloader.js"></script>
+			<script type="text/javascript" src="src/game/MainMenu.js"></script>
+			<script type="text/javascript" src="src/game/Game.js"></script>
+			<script type="text/javascript" src="src/game/GameLayer3d.js"></script>
+			<script type="text/javascript" src="src/game/About.js"></script>
+		</section>
+
+		<!--TODO: Need to insert the cordova.js script node at build time.-->
+		<script type="text/javascript" src="cordova.js"></script>
+
+		<script type="text/javascript">
+			window.onload = function()
+			{
+			  GameTitle.run();
+			}
+		</script>
+	</body>
 
 </html>

--- a/www/src/game/GameTitle.js
+++ b/www/src/game/GameTitle.js
@@ -129,7 +129,8 @@ GameTitle.cycleActiveButton = function( direction )
   }
   else
   {
-    var currentIndex = index = state.buttonList.indexOf( GameTitle.activeButton );
+    index = state.buttonList.indexOf( GameTitle.activeButton );
+    var currentIndex = index;
 
     index += direction;
     if( index >= state.buttonList.length )

--- a/www/src/game/JsUtils.js
+++ b/www/src/game/JsUtils.js
@@ -1,3 +1,5 @@
+/*jshint -W069*/
+
 // Function to facilitate Javascript "class" inheritence.
 function extend( subConstructor, superConstructor )
 {
@@ -15,7 +17,7 @@ function extend( subConstructor, superConstructor )
   subConstructor.prototype = Object.create( superConstructor.prototype, constructor );
 }
 
-window["extend"] = extend;
+window["extend"] = extend; // Google Closure
 
 // Function to provide traditional string comparison.
 // Returns -1, if string1 < string2.
@@ -26,4 +28,4 @@ function strcmp( string1, string2 )
   return string1 < string2 ? -1 : ( string1 > string2 ? 1 : 0 );
 }
 
-window["strcmp"] = strcmp;
+window["strcmp"] = strcmp; // Google Closure


### PR DESCRIPTION
@thrabchak, I ran the updated grunt lint and saw current offenders.

Looks like most in index.html were likely typos. I moved the <section> node into body to fix the header jshint error. I also fixed some tab alignment (not something that was breaking jshint).

The offense in GameTitle.js seemed a bit weak to me, as it is safer (if intended, as it was). Regardless, I changed it to appease jshint.

The offense in JsUtils.js may not be remedied properly, given its purpose. jshint complains of the lack of using dot notation. Google Closure (another minifying tool) uses this mechanism to ensure certain symbols are not minified. Such is useful for creating an API that is accessible by third parties (eg the symbol Phaser). Another good example is the code for embedding Google Analytics into a web app--Google servers must be able to identify certain symbols in source.

I added the command to JsUtils.js to skip this warning and then notated the Google Closure intended lines of code. If Phaser uses both jshint and uglify, perhaps we can better remedy this situation by following suite with whatever Phaser does. We may find that Google Closure does a better job in the future, but for the current situation, I'm content with saying we support uglify.

Given these changes, grunt lint now passes.